### PR TITLE
Removes skeleton keys

### DIFF
--- a/code/datums/components/crafting/misc.dm
+++ b/code/datums/components/crafting/misc.dm
@@ -6,14 +6,6 @@
 	result = /obj/item/paper_bin/bundlenatural
 	category = CAT_MISC
 
-/datum/crafting_recipe/skeleton_key
-	name = "Skeleton Key"
-	time = 3 SECONDS
-	reqs = list(/obj/item/stack/sheet/bone = 5)
-	result = /obj/item/skeleton_key
-	always_available = FALSE
-	category = CAT_MISC
-
 /datum/crafting_recipe/coffee_cartridge
 	name = "Bootleg Coffee Cartridge"
 	result = /obj/item/coffee_cartridge/bootleg

--- a/code/game/area/areas/shuttles.dm
+++ b/code/game/area/areas/shuttles.dm
@@ -281,8 +281,7 @@
 		to_chat(L, "<span class='reallybig redtext'>The battle is won. Your bloodlust subsides.</span>", confidential = TRUE)
 		for(var/obj/item/chainsaw/doomslayer/chainsaw in L)
 			qdel(chainsaw)
-		var/obj/item/skeleton_key/key = new(L)
-		L.put_in_hands(key)
+
 	else
 		to_chat(L, span_warning("You are not yet worthy of passing. Drag a severed head to the barrier to be allowed entry to the hall of champions."), confidential = TRUE)
 

--- a/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
+++ b/code/game/machinery/computer/orders/order_items/mining/order_mining.dm
@@ -5,10 +5,6 @@
 	item_path = /obj/item/stack/marker_beacon/ten
 	cost_per_order = 100
 
-/datum/orderable_item/mining/skeleton_key
-	item_path = /obj/item/skeleton_key
-	cost_per_order = 777
-
 /datum/orderable_item/mining/mining_stabilizer
 	item_path = /obj/item/mining_stabilizer
 	cost_per_order = 400

--- a/code/modules/antagonists/ashwalker/ashwalker.dm
+++ b/code/modules/antagonists/ashwalker/ashwalker.dm
@@ -27,7 +27,6 @@
 /datum/antagonist/ashwalker/on_gain()
 	. = ..()
 	RegisterSignal(owner.current, COMSIG_MOB_EXAMINATE, PROC_REF(on_examinate))
-	owner.teach_crafting_recipe(/datum/crafting_recipe/skeleton_key)
 
 /datum/antagonist/ashwalker/on_removal()
 	. = ..()

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -10,17 +10,10 @@
 	paint_jobs = null
 
 /obj/structure/closet/crate/necropolis/tendril
-	desc = "It's watching you suspiciously. You need a skeleton key to open it."
-	integrity_failure = 0 //prevents bust_open from firing
-	/// var to check if it got opened by a key
-	var/spawned_loot = FALSE
+	desc = "It's watching you suspiciously."
 
-/obj/structure/closet/crate/necropolis/tendril/attackby(obj/item/item, mob/user, params)
-	if(!istype(item, /obj/item/skeleton_key) || spawned_loot)
-		return ..()
-	var/loot = rand(1,20)
-	var/mod
-	switch(loot)
+/obj/structure/closet/crate/necropolis/tendril/PopulateContents()
+	switch(rand(1,20))
 		if(1)
 			new /obj/item/shared_storage/red(src)
 		if(2)
@@ -34,8 +27,7 @@
 		if(6)
 			new /obj/item/clothing/gloves/gauntlets(src)
 		if(7)
-			mod = rand(1,4)
-			switch(mod)
+			switch(rand(1,4))
 				if(1)
 					new /obj/item/disk/design_disk/modkit_disc/resonator_blast(src)
 				if(2)
@@ -71,23 +63,6 @@
 			new /obj/item/bedsheet/cult(src)
 		if(20)
 			new /obj/item/clothing/neck/necklace/memento_mori(src)
-	if(!contents.len)
-		to_chat(user, span_warning("[src] makes a clunking sound as you try to open it. You feel compelled to let the gods know! (Please open an adminhelp and try again!)"))
-		CRASH("Failed to generate loot. loot number: [loot][mod ? "subloot: [mod]" : null]")
-	spawned_loot = TRUE
-	qdel(item)
-	to_chat(user, span_notice("You disable the magic lock, revealing the loot."))
-
-/obj/structure/closet/crate/necropolis/tendril/before_open(mob/living/user, force)
-	. = ..()
-	if(!.)
-		return FALSE
-
-	if(!broken && !force && !spawned_loot)
-		balloon_alert(user, "its locked!")
-		return FALSE
-
-	return TRUE
 
 //Megafauna chests
 
@@ -173,10 +148,3 @@
 			new /obj/item/wisp_lantern(src)
 		if(3)
 			new /obj/item/prisoncube(src)
-
-/obj/item/skeleton_key
-	name = "skeleton key"
-	desc = "An artifact usually found in the hands of the natives of lavaland, which NT now holds a monopoly on."
-	icon = 'icons/obj/lavaland/artefacts.dmi'
-	icon_state = "skeleton_key"
-	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
## About The Pull Request

Miners now can open crates without being arbitrarily locked

## Why It's Good For The Game

It probably isn't.

## Changelog

:cl:
balance: skeleton keys have been removed
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
