### PR TITLE
BASED holidays

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -37,6 +37,7 @@
 //based Novus exclusive holidays
 #define STONEWALL_WEEK "Stonewall Riots Week"
 #define KILLDOZER_DAY "Killdozer Day"
+#define UNCLE_TED_DAY "Uncle Ted Day"
 
 /*
 

--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -33,8 +33,11 @@
 #define FESTIVE_SEASON "Festive Season"
 #define GARBAGEDAY "Garbage Day"
 #define MONKEYDAY "Monkey Day"
-#define PRIDE_WEEK "Pride Week"
-#define MOTH_WEEK "Moth Week"
+
+//based Novus exclusive holidays
+#define STONEWALL_WEEK "Stonewall Riots Week"
+#define KILLDOZER_DAY "Killdozer Day"
+
 /*
 
 Days of the week to make it easier to reference them.

--- a/code/__DEFINES/turfs.dm
+++ b/code/__DEFINES/turfs.dm
@@ -105,6 +105,8 @@
 #define PATTERN_RANDOM "random"
 /// Generate rainbow color turf decals
 #define PATTERN_RAINBOW "rainbow"
+/// Generate PATRIOTIC color turf decals
+#define PATTERN_AMERICAN "american"
 
 /**
  * Finds the midpoint of two given turfs.

--- a/code/datums/components/armor_plate.dm
+++ b/code/datums/components/armor_plate.dm
@@ -92,3 +92,11 @@
 		if(!LAZYLEN(mech.occupants))
 			overlay_string += "-open"
 		overlays += overlay_string
+
+/datum/component/armor_plate/proc/fully_upgrade()
+	var/atom/atom_parent = parent
+	while(amount < maxamount)
+		amount++
+		atom_parent.set_armor(atom_parent.get_armor().add_other_armor(armor_mod))
+		SEND_SIGNAL(atom_parent, COMSIG_ARMOR_PLATED, amount, maxamount)
+	atom_parent.update_appearance()

--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -87,7 +87,7 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	. = ..()
 
 	Reset()
-	if(check_holidays(UNCLE_TED_DAY))  //rip uncle ted
+	if(check_holidays(UNCLE_TED_DAY)) //rip uncle ted
 		emag_act()
 
 /obj/machinery/computer/arcade/proc/prizevend(mob/living/user, prizes = 1)

--- a/code/game/machinery/computer/arcade/arcade.dm
+++ b/code/game/machinery/computer/arcade/arcade.dm
@@ -87,6 +87,8 @@ GLOBAL_LIST_INIT(arcade_prize_pool, list(
 	. = ..()
 
 	Reset()
+	if(check_holidays(UNCLE_TED_DAY))  //rip uncle ted
+		emag_act()
 
 /obj/machinery/computer/arcade/proc/prizevend(mob/living/user, prizes = 1)
 	SEND_SIGNAL(src, COMSIG_ARCADE_PRIZEVEND, user, prizes)

--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -81,8 +81,6 @@
 					var/mob/living/carbon/human/human = M
 					if(!(human.mob_biotypes & (MOB_ROBOTIC|MOB_MINERAL|MOB_UNDEAD|MOB_SPIRIT)))
 						var/datum/species/species_to_transform = /datum/species/fly
-						if(check_holidays(MOTH_WEEK))
-							species_to_transform = /datum/species/moth
 						if(human.dna && human.dna.species.id != initial(species_to_transform.id))
 							to_chat(M, span_hear("You hear a buzzing in your ears."))
 							human.set_species(species_to_transform)

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -92,8 +92,11 @@
 		if(PATTERN_RANDOM)
 			return "#[random_short_color()]"
 		if(PATTERN_RAINBOW)
-			var/datum/holiday/pride_week/rainbow_datum = new()
+			var/datum/holiday/stonewall_week/rainbow_datum = new()
 			return rainbow_datum.get_holiday_colors(thing_to_color, PATTERN_DEFAULT)
+		if(PATTERN_AMERICAN)
+			var/datum/holiday/usa/patriot_datum = new()
+			return patriot_datum.get_holiday_colors(thing_to_color, PATTERN_DEFAULT)
 	if(!length(GLOB.holidays))
 		return
 	for(var/holiday_key in GLOB.holidays)
@@ -103,18 +106,6 @@
 // The actual holidays
 
 // JANUARY
-
-//Fleet Day is celebrated on Jan 19th, the date on which moths were merged (#34498)
-/datum/holiday/fleet_day
-	name = "Fleet Day"
-	begin_month = JANUARY
-	begin_day = 19
-
-/datum/holiday/fleet_day/greet()
-	return "This day commemorates another year of successful survival aboard the Mothic Grand Nomad Fleet. Moths galaxywide are encouraged to eat, drink, and be merry."
-
-/datum/holiday/fleet_day/getStationPrefix()
-	return pick("Moth", "Fleet", "Nomadic")
 
 // FEBRUARY
 
@@ -261,6 +252,9 @@
 	name = "Four-Twenty"
 	begin_day = 20
 	begin_month = APRIL
+	holiday_colors = list(
+		COLOR_GREEN,
+	) //dude weed lmao
 
 /datum/holiday/fourtwenty/getStationPrefix()
 	return pick("Snoop","Blunt","Toke","Dank","Cheech","Chong")
@@ -297,18 +291,6 @@
 	drone_hat = /obj/item/clothing/head/utility/hardhat
 	mail_holiday = TRUE
 
-//Draconic Day is celebrated on May 3rd, the date on which the Draconic language was merged (#26780)
-/datum/holiday/draconic_day
-	name = "Draconic Language Day"
-	begin_month = MAY
-	begin_day = 3
-
-/datum/holiday/draconic_day/greet()
-	return "On this day, Lizardkind celebrates their language with literature and other cultural works."
-
-/datum/holiday/draconic_day/getStationPrefix()
-	return pick("Draconic", "Literature", "Reading")
-
 /datum/holiday/firefighter
 	name = "Firefighter's Day"
 	begin_day = 4
@@ -329,17 +311,17 @@
 
 // JUNE
 
-//The Festival of Atrakor's Might (Tizira's Moon) is celebrated on June 15th, the date on which the lizard visual revamp was merged (#9808)
-/datum/holiday/atrakor_festival
-	name = "Festival of Atrakor's Might"
+//Day of Marvin Heemeyer's wrath against Granby, Colorado
+/datum/holiday/killdozer_day
+	name = "Killdozer Day"
+	begin_day = 4
 	begin_month = JUNE
-	begin_day = 15
 
-/datum/holiday/atrakor_festival/greet()
-	return "On this day, the Lizards traditionally celebrate the Festival of Atrakor's Might, where they honour the moon god with lavishly adorned clothing, large portions of food, and a massive celebration into the night."
+/datum/holiday/killdozer_day/greet()
+	return "On June 4th, 2004 Marvin Heemeyer lowered the armored shell over top of himself, entombing himself inside the Killdozer to make his last stand."
 
-/datum/holiday/atrakor_festival/getStationPrefix()
-	return pick("Moon", "Night Sky", "Celebration")
+/datum/holiday/killdozer_day/getStationPrefix()
+	return pick("Retribution", "Rampage", "Tread", "Bulldozer", "Muffler Shop", "Granby")
 
 /// Garbage DAYYYYY
 /// Huh?.... NOOOO
@@ -348,7 +330,6 @@
 /datum/holiday/garbageday
 	name = GARBAGEDAY
 	begin_day = 17
-	end_day = 17
 	begin_month = JUNE
 
 /datum/holiday/summersolstice
@@ -356,19 +337,21 @@
 	begin_day = 21
 	begin_month = JUNE
 
-/datum/holiday/pride_week
-	name = PRIDE_WEEK
+//i'd really love to somehow make gay people spawn with baseball bats and such on stonewall riots week
+//but how the fuck do i code a gay detection system
+/datum/holiday/stonewall_week
+	name = STONEWALL_WEEK
+	begin_day = 28
 	begin_month = JUNE
-	// Stonewall was June 28th, this captures its week.
-	begin_day = 23
-	end_day = 29
+	end_day = 3
+	end_month = JULY
 	holiday_colors = list(
-	COLOR_PRIDE_PURPLE,
-	COLOR_PRIDE_BLUE,
-	COLOR_PRIDE_GREEN,
-	COLOR_PRIDE_YELLOW,
-	COLOR_PRIDE_ORANGE,
-	COLOR_PRIDE_RED,
+		COLOR_PRIDE_PURPLE,
+		COLOR_PRIDE_BLUE,
+		COLOR_PRIDE_GREEN,
+		COLOR_PRIDE_YELLOW,
+		COLOR_PRIDE_ORANGE,
+		COLOR_PRIDE_RED,
 	)
 
 // JULY
@@ -394,9 +377,18 @@
 	begin_day = 4
 	begin_month = JULY
 	mail_holiday = TRUE
+	holiday_colors = list(
+		"#0A3161",
+		"#B31942",
+		"#FFFFFF",
+		"#B31942",
+		"#FFFFFF",
+		"#B31942",
+		"#FFFFFF",
+	) //oh say can you see...
 
 /datum/holiday/usa/getStationPrefix()
-	return pick("Independent","American","Burger","Bald Eagle","Star-Spangled", "Fireworks")
+	return pick("Independent","American","Burger","Bald Eagle","Star-Spangled","Fireworks","Gun-Toting","Freedom")
 
 /datum/holiday/writer
 	name = "Writer's Day"
@@ -464,18 +456,6 @@
 	return pick("Kyiv", "Ukraine")
 
 // SEPTEMBER
-
-//Tiziran Unification Day is celebrated on Sept 1st, the day on which lizards were made a roundstart race
-/datum/holiday/tiziran_unification
-	name = "Tiziran Unification Day"
-	begin_month = SEPTEMBER
-	begin_day = 1
-
-/datum/holiday/tiziran_unification/greet()
-	return "On this day over 400 years ago, Lizardkind first united under a single banner, ready to face the stars as one unified people."
-
-/datum/holiday/tiziran_unification/getStationPrefix()
-	return pick("Tizira", "Lizard", "Imperial")
 
 /datum/holiday/ianbirthday
 	name = "Ian's Birthday" //github.com/tgstation/tgstation/commit/de7e4f0de0d568cd6e1f0d7bcc3fd34700598acb

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -312,16 +312,28 @@
 // JUNE
 
 //Day of Marvin Heemeyer's wrath against Granby, Colorado
-/datum/holiday/killdozer_day
-	name = "Killdozer Day"
+/datum/holiday/killdozer
+	name = KILLDOZER_DAY
 	begin_day = 4
 	begin_month = JUNE
 
-/datum/holiday/killdozer_day/greet()
-	return "On June 4th, 2004 Marvin Heemeyer lowered the armored shell over top of himself, entombing himself inside the Killdozer to make his last stand."
+/datum/holiday/killdozer/greet()
+	return "On June 4th, 2004 Marvin John Heemeyer lowered the armored shell over top of himself, entombing himself inside the Killdozer to make his last stand."
 
-/datum/holiday/killdozer_day/getStationPrefix()
+/datum/holiday/killdozer/getStationPrefix()
 	return pick("Retribution", "Rampage", "Tread", "Bulldozer", "Muffler Shop", "Granby")
+
+//RIP Ted, we will miss you
+/datum/holiday/uncle_ted
+	name = UNCLE_TED_DAY
+	begin_day = 10
+	begin_month = JUNE
+
+/datum/holiday/uncle_ted/greet()
+	return "On June 10th, 2023 Theodore John Kaczynski died in his prison cell at the Federal Medical Center in Butner, North Carolina."
+
+/datum/holiday/uncle_ted/getStationPrefix()
+	return pick("Industrial Society", "Anarcho-Primitivist", "Luddite", "Eco-Terrorist")
 
 /// Garbage DAYYYYY
 /// Huh?.... NOOOO

--- a/code/modules/holiday/nth_week.dm
+++ b/code/modules/holiday/nth_week.dm
@@ -66,21 +66,3 @@
 
 /datum/holiday/beer/getStationPrefix()
 	return pick("Stout","Porter","Lager","Ale","Malt","Bock","Doppelbock","Hefeweizen","Pilsner","IPA","Lite") //I'm sorry for the last one
-
-/datum/holiday/nth_week/moth
-	name = MOTH_WEEK
-	begin_week = 3
-	end_week = 4
-	begin_month = JULY
-	begin_weekday = SATURDAY
-	end_weekday = SUNDAY
-
-//National Moth Week falls on the last full week of July, including the saturday and sunday before. See http://nationalmothweek.org/ for precise tracking.
-/datum/holiday/nth_week/moth/shouldCelebrate(dd, mm, yyyy, ddd)
-	if(first_day_of_month(yyyy, mm) >= 5) //Friday or later start of the month means week 5 is a full week.
-		begin_week += 1
-		end_week += 1
-	return ..(dd, mm, yyyy, ddd)
-
-/datum/holiday/nth_week/moth/getStationPrefix()
-	return pick("Mothball","Lepidopteran","Lightbulb","Moth","Giant Atlas","Twin-spotted Sphynx","Madagascan Sunset","Luna","Death's Head","Emperor Gum","Polyphenus","Oleander Hawk","Io","Rosy Maple","Cecropia","Noctuidae","Giant Leopard","Dysphania Militaris","Garden Tiger")

--- a/code/modules/jobs/job_types/roboticist.dm
+++ b/code/modules/jobs/job_types/roboticist.dm
@@ -56,6 +56,11 @@
 	pda_slot = ITEM_SLOT_LPOCKET
 	skillchips = list(/obj/item/skillchip/job/roboticist)
 
+/datum/outfit/job/roboticist/pre_equip(mob/living/carbon/human/H, visualsOnly)
+	. = ..()
+	if(check_holidays(KILLDOZER_DAY))
+		r_hand = /obj/item/toy/mecha/deathripley
+
 /datum/outfit/job/roboticist/mod
 	name = "Roboticist (MODsuit)"
 	suit_store = /obj/item/tank/internals/oxygen

--- a/code/modules/unit_tests/holidays.dm
+++ b/code/modules/unit_tests/holidays.dm
@@ -27,22 +27,3 @@
 /datum/unit_test/new_year_1983/Run()
 	var/datum/holiday/new_year/new_year = new
 	TEST_ASSERT(new_year.shouldCelebrate(2, JANUARY, 1983, SUNDAY), "January 2, 1983 was not New Year.")
-
-/datum/unit_test/moth_week_2020/Run()
-	// We expect 2 year's worth of moth week, falling on the last full week of july
-	// We test ahead and behind just in case something's fucked
-	// Both lists are in the form yyyy/m/d
-	var/list/produced_moth_days = poll_holiday(/datum/holiday/nth_week/moth, 6, 8, 2020, 2021, 31)
-	var/list/predicted_moth_days = list()
-	for(var/day in 18 to 26) // Last full week of July 2020
-		predicted_moth_days += "2020/7/[day]"
-	for(var/day in 17 to 25) // Last full week of July 2021
-		predicted_moth_days += "2021/7/[day]"
-	var/list/unexpected_moths = produced_moth_days - predicted_moth_days
-	for(var/date in unexpected_moths)
-		TEST_FAIL("[date] was improperly Moth Week")
-
-	var/list/missing_moths = predicted_moth_days - produced_moth_days
-	for(var/date in missing_moths)
-		TEST_FAIL("[date] was not Moth Week")
-

--- a/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
+++ b/code/modules/vehicles/mecha/equipment/tools/work_tools.dm
@@ -22,7 +22,7 @@
 	///Audio for using the hydraulic clamp
 	var/clampsound = 'sound/mecha/hydraulic.ogg'
 
-/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/attach(obj/vehicle/sealed/mecha/new_mecha)
+/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/attach(obj/vehicle/sealed/mecha/new_mecha, attach_right = FALSE)
 	. = ..()
 	if(istype(chassis, /obj/vehicle/sealed/mecha/ripley))
 		cargo_holder = chassis

--- a/code/modules/vehicles/mecha/working/ripley.dm
+++ b/code/modules/vehicles/mecha/working/ripley.dm
@@ -195,6 +195,26 @@ GLOBAL_DATUM(cargo_ripley, /obj/vehicle/sealed/mecha/ripley/cargo)
 	if(!GLOB.cargo_ripley && mapload)
 		GLOB.cargo_ripley = src
 
+	if(check_holidays(KILLDOZER_DAY))
+		//NAHHH, today the cargo ripley gets an upgrade alright
+		name = "\proper KILLDOZER"
+		desc = "Sometimes reasonable men must do unreasonable things."
+		max_integrity = 300
+		repair_damage(max_integrity)
+		for(var/key in equip_by_category)
+			for(var/obj/item/mecha_parts/mecha_equipment/equipment as anything in equip_by_category[key])
+				equipment.detach()
+				qdel(equipment)
+		var/obj/item/mecha_parts/mecha_equipment/hydraulic_clamp/kill/kill_clamp = new(src)
+		kill_clamp.attach(src, TRUE)
+		var/obj/item/mecha_parts/mecha_equipment/ejector/ejector = new(src)
+		ejector.attach(src)
+		var/datum/component/armor_plate/armor_plate = GetComponent(/datum/component/armor_plate)
+		if(armor_plate)
+			armor_plate.fully_upgrade()
+		var/list/greyscale = list(0.3,0.3,0.3, 0.59,0.59,0.59, 0.11,0.11,0.11, 0,0,0)
+		add_atom_colour(greyscale, FIXED_COLOUR_PRIORITY)
+
 /obj/vehicle/sealed/mecha/ripley/cargo/Destroy()
 	if(GLOB.cargo_ripley == src)
 		GLOB.cargo_ripley = null


### PR DESCRIPTION
## About The Pull Request

Replaces pride week with stonewall riots week
Adds Killdozer Day as a holiday on June 4th, which replaces the cargo ripley with a KILLDOZER and gives the roboticist a toy death ripley
Adds Uncle Ted Day as a holiday on June 22th, which makes all arcade machines get emagged
Gives four-twenty and independence day holiday colors
Nukes all moth related holidays
Nukes all lizard related holidays

## Why It's Good For The Game

It's still pandering, but like, it's pandering to ME so it's better.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

hmmm no