### PR TITLE
[DRAFT] Adds ghost role customization + prettifies char setup

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -40,6 +40,26 @@ GLOBAL_LIST_EMPTY(bots_list)
 GLOBAL_LIST_EMPTY(aiEyes)
 GLOBAL_LIST_EMPTY(suit_sensors_list) //all people with suit sensors on
 
+GLOBAL_LIST_EMPTY(roundstart_races)
+///List of all roundstart languages by path
+GLOBAL_LIST_EMPTY(roundstart_languages)
+
+/// An assoc list of species types to their features (from get_features())
+GLOBAL_LIST_EMPTY(features_by_species)
+
+GLOBAL_LIST_INIT(offstation_customization_by_save_key, init_offstation_customization()) // i hate this name
+GLOBAL_LIST_INIT(valid_char_savekeys, init_valid_savekeys())
+
+/proc/init_offstation_customization()
+	. = list()
+	for(var/datum/offstation_customization/subtype as anything in subtypesof(/datum/offstation_customization))
+		.[initial(subtype.savefile_key)] = new subtype
+
+/proc/init_valid_savekeys()
+	. = list("main")
+	for(var/key in GLOB.offstation_customization_by_save_key)
+		. += key
+
 /// All alive mobs with clients.
 GLOBAL_LIST_EMPTY(alive_player_list)
 

--- a/code/datums/json_savefile.dm
+++ b/code/datums/json_savefile.dm
@@ -11,7 +11,7 @@
 	/// Cooldown that tracks the time between attempts to download the savefile.
 	COOLDOWN_DECLARE(download_cooldown)
 
-GENERAL_PROTECT_DATUM(/datum/json_savefile)
+//GENERAL_PROTECT_DATUM(/datum/json_savefile)
 
 /datum/json_savefile/New(path)
 	src.path = path

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -7,9 +7,16 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	/// Whether or not we allow saving/loading. Used for guests, if they're enabled
 	var/load_and_save = TRUE
 	/// Ensures that we always load the last used save, QOL
-	var/default_slot = 1
+	var/current_char_id = 1
+	/// The current charset we're editing. "main" for station characters, everything else in GLOB.valid_char_savekeys
+	var/current_char_key = "main"
+
 	/// The maximum number of slots we're allowed to contain
 	var/max_save_slots = 3
+	/// Above, but for ghost roles.
+	var/max_ghost_role_slots = 2
+	/// The amount of main slots we're actually using. Assoc list of character savekeys to the amount of slots used.
+	var/list/used_slot_amount = list()
 
 	/// Bitflags for communications that are muted
 	var/muted = NONE
@@ -97,7 +104,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/New(client/parent)
 	src.parent = parent
 
-	for (var/middleware_type in subtypesof(/datum/preference_middleware))
+	for(var/middleware_type in subtypesof(/datum/preference_middleware))
 		middleware += new middleware_type(src)
 
 	if(IS_CLIENT_OR_MOCK(parent))
@@ -122,7 +129,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		if(load_character())
 			return
 	//we couldn't load character data so just randomize the character appearance + name
-	randomise_appearance_prefs() //let's create a random character then - rather than a fat, bald and naked man.
+	//randomise_appearance_prefs() //let's create a random character then - rather than a fat, bald and naked man.
 	if(parent)
 		apply_all_client_preferences()
 		parent.set_macros()
@@ -162,15 +169,16 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/ui_data(mob/user)
 	var/list/data = list()
 
-	if (tainted_character_profiles)
+	if(tainted_character_profiles)
 		data["character_profiles"] = create_character_profiles()
 		tainted_character_profiles = FALSE
 
 	data["character_preferences"] = compile_character_preferences(user)
 
-	data["active_slot"] = default_slot
+	data["active_slot_id"] = current_char_id
+	data["active_slot_key"] = current_char_key
 
-	for (var/datum/preference_middleware/preference_middleware as anything in middleware)
+	for(var/datum/preference_middleware/preference_middleware as anything in middleware)
 		data += preference_middleware.get_ui_data(user)
 
 	return data
@@ -184,9 +192,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	data["overflow_role"] = SSjob.GetJobType(SSjob.overflow_role).title
 	data["window"] = current_window
 
+	data["max_slots_main"] = max_save_slots
+	data["max_slots_ghost"] = max_ghost_role_slots
+
 	data["content_unlocked"] = unlock_content
 
-	for (var/datum/preference_middleware/preference_middleware as anything in middleware)
+	for(var/datum/preference_middleware/preference_middleware as anything in middleware)
 		data += preference_middleware.get_ui_static_data(user)
 
 	return data
@@ -197,65 +208,74 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		get_asset_datum(/datum/asset/json/preferences),
 	)
 
-	for (var/datum/preference_middleware/preference_middleware as anything in middleware)
+	for(var/datum/preference_middleware/preference_middleware as anything in middleware)
 		assets += preference_middleware.get_ui_assets()
 
 	return assets
 
 /datum/preferences/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
 	. = ..()
-	if (.)
+	if(.)
 		return
 
 	switch (action)
-		if ("change_slot")
+		if("change_slot")
 			// Save existing character
 			save_character()
 
 			// SAFETY: `load_character` performs sanitization the slot number
-			if (!load_character(params["slot"]))
+			if(!load_character(params["slot_key"], params["slot_id"]))
 				tainted_character_profiles = TRUE
-				randomise_appearance_prefs()
+				//randomise_appearance_prefs()
 				save_character()
 
-			for (var/datum/preference_middleware/preference_middleware as anything in middleware)
+			for(var/datum/preference_middleware/preference_middleware as anything in middleware)
 				preference_middleware.on_new_character(usr)
 
 			character_preview_view.update_body()
 
 			return TRUE
-		if ("rotate")
+
+		if("new_slot")
+			tainted_character_profiles = TRUE
+			if(add_character_slot(params["slot_key"]))
+				load_character("main", used_slot_amount["main"]) //load the new char
+			return TRUE
+
+		if("rotate")
 			character_preview_view.dir = turn(character_preview_view.dir, -90)
 
 			return TRUE
-		if ("set_preference")
+
+		if("set_preference")
 			var/requested_preference_key = params["preference"]
 			var/value = params["value"]
 
-			for (var/datum/preference_middleware/preference_middleware as anything in middleware)
-				if (preference_middleware.pre_set_preference(usr, requested_preference_key, value))
+			for(var/datum/preference_middleware/preference_middleware as anything in middleware)
+				if(preference_middleware.pre_set_preference(usr, requested_preference_key, value))
 					return TRUE
 
 			var/datum/preference/requested_preference = GLOB.preference_entries_by_key[requested_preference_key]
-			if (isnull(requested_preference))
+			if(isnull(requested_preference))
 				return FALSE
 
 			// SAFETY: `update_preference` performs validation checks
-			if (!update_preference(requested_preference, value))
+			if(!update_preference(requested_preference, value))
 				return FALSE
 
-			if (istype(requested_preference, /datum/preference/name))
+			if(istype(requested_preference, /datum/preference/name))
 				tainted_character_profiles = TRUE
 
 			return TRUE
-		if ("set_color_preference")
+
+		if("set_color_preference")
 			var/requested_preference_key = params["preference"]
 
 			var/datum/preference/requested_preference = GLOB.preference_entries_by_key[requested_preference_key]
-			if (isnull(requested_preference))
+			if(isnull(requested_preference))
 				return FALSE
 
-			if (!istype(requested_preference, /datum/preference/color))
+			if(!istype(requested_preference, /datum/preference/color))
 				return FALSE
 
 			var/default_value = read_preference(requested_preference.type)
@@ -268,26 +288,27 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				default_value || COLOR_WHITE,
 			) as color | null
 
-			if (!new_color)
+			if(!new_color)
 				return FALSE
 
-			if (!update_preference(requested_preference, new_color))
+			if(!update_preference(requested_preference, new_color))
 				return FALSE
 
 			return TRUE
+
 		if("set_tricolor_preference")
 			var/requested_preference_key = params["preference"]
 			var/requested_preference_index = params["value"]
 
 			var/datum/preference/requested_preference = GLOB.preference_entries_by_key[requested_preference_key]
-			if (isnull(requested_preference))
+			if(isnull(requested_preference))
 				return FALSE
 
-			if (!istype(requested_preference, /datum/preference/tricolor))
+			if(!istype(requested_preference, /datum/preference/tricolor))
 				return FALSE
 
 			var/list/color_list = read_preference(requested_preference.type)
-			if (!islist(color_list))
+			if(!islist(color_list))
 				return FALSE //wtf?
 
 			var/default_value = sanitize_hexcolor(color_list[requested_preference_index], DEFAULT_HEX_COLOR_LEN, include_crunch = TRUE)
@@ -299,18 +320,18 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				null,
 				default_value || COLOR_WHITE,
 			) as color | null
-			if (!new_color)
+			if(!new_color)
 				return FALSE
 
 			color_list[requested_preference_index] = new_color
-			if (!update_preference(requested_preference, jointext(color_list, ";")))
+			if(!update_preference(requested_preference, jointext(color_list, ";")))
 				return FALSE
 
 			return TRUE
 
-	for (var/datum/preference_middleware/preference_middleware as anything in middleware)
+	for(var/datum/preference_middleware/preference_middleware as anything in middleware)
 		var/delegation = preference_middleware.action_delegations[action]
-		if (!isnull(delegation))
+		if(!isnull(delegation))
 			return call(preference_middleware, delegation)(params, usr)
 
 	return FALSE
@@ -322,10 +343,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 /datum/preferences/Topic(href, list/href_list)
 	. = ..()
-	if (.)
+	if(.)
 		return
 
-	if (href_list["open_keybindings"])
+	if(href_list["open_keybindings"])
 		current_window = PREFERENCE_TAB_KEYBINDINGS
 		update_static_data(usr)
 		ui_interact(usr)
@@ -342,8 +363,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/proc/compile_character_preferences(mob/user)
 	var/list/preferences = list()
 
-	for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
-		if (!preference.is_accessible(src))
+	for(var/datum/preference/preference as anything in get_preferences_in_priority_order())
+		if(!preference.is_accessible(src))
 			continue
 
 		LAZYINITLIST(preferences[preference.category])
@@ -353,13 +374,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 		preferences[preference.category][preference.savefile_key] = data
 
-	for (var/datum/preference_middleware/preference_middleware as anything in middleware)
+	for(var/datum/preference_middleware/preference_middleware as anything in middleware)
 		var/list/append_character_preferences = preference_middleware.get_character_preferences(user)
-		if (isnull(append_character_preferences))
+		if(isnull(append_character_preferences))
 			continue
 
-		for (var/category in append_character_preferences)
-			if (category in preferences)
+		for(var/category in append_character_preferences)
+			if(category in preferences)
 				preferences[category] += append_character_preferences[category]
 			else
 				preferences[category] = append_character_preferences[category]
@@ -368,8 +389,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 /// Applies all PREFERENCE_PLAYER preferences
 /datum/preferences/proc/apply_all_client_preferences()
-	for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
-		if (preference.savefile_identifier != PREFERENCE_PLAYER)
+	for(var/datum/preference/preference as anything in get_preferences_in_priority_order())
+		if(preference.savefile_identifier != PREFERENCE_PLAYER)
 			continue
 
 		value_cache -= preference.type
@@ -396,7 +417,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 /// Updates the currently displayed body
 /atom/movable/screen/map_view/char_preview/proc/update_body()
-	if (isnull(body))
+	if(isnull(body))
 		create_body()
 	else
 		body.wipe_state()
@@ -411,31 +432,32 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	body.appearance_flags &= ~KEEP_TOGETHER
 
 /datum/preferences/proc/create_character_profiles()
-	var/list/profiles = list()
+	var/list/profiles = list("main" = list())
 
-	for (var/index in 1 to max_save_slots)
-		// It won't be updated in the savefile yet, so just read the name directly
-		if (index == default_slot)
-			profiles += read_preference(/datum/preference/name/real_name)
-			continue
-
-		var/tree_key = "character[index]"
-		var/save_data = savefile.get_entry(tree_key)
+	for(var/index in 1 to used_slot_amount["main"])
+		var/save_data = savefile.get_entry("character_main_[index]")
 		var/name = save_data?["real_name"]
 
-		if (isnull(name))
-			profiles += null
-			continue
+		profiles["main"] += name
 
-		profiles += name
+	for(var/save_key in GLOB.valid_char_savekeys - "main")
+		profiles[save_key] = null //insert blank data
+		for(var/index in 1 to max_ghost_role_slots)
+			var/save_data = savefile.get_entry("character_[save_key]_[index]")
+			var/name = save_data?["real_name"]
+
+			if(isnull(name))
+				break
+
+			LAZYADD(profiles[save_key], name)
 
 	return profiles
 
 /datum/preferences/proc/set_job_preference_level(datum/job/job, level)
-	if (!job)
+	if(!job)
 		return FALSE
 
-	if (level == JP_HIGH)
+	if(level == JP_HIGH)
 		var/datum/job/overflow_role = SSjob.overflow_role
 		var/overflow_role_title = initial(overflow_role.title)
 
@@ -480,8 +502,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/proc/apply_prefs_to(mob/living/carbon/human/character, icon_updates = TRUE)
 	character.dna.features = list()
 
-	for (var/datum/preference/preference as anything in get_preferences_in_priority_order())
-		if (preference.savefile_identifier != PREFERENCE_CHARACTER)
+	for(var/datum/preference/preference as anything in get_preferences_in_priority_order())
+		if(preference.savefile_identifier != PREFERENCE_CHARACTER)
 			continue
 
 		preference.apply_to_human(character, read_preference(preference.type), src)
@@ -508,8 +530,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/proc/get_key_bindings_by_key(list/key_bindings)
 	var/list/output = list()
 
-	for (var/action in key_bindings)
-		for (var/key in key_bindings[action])
+	for(var/action in key_bindings)
+		for(var/key in key_bindings[action])
 			LAZYADD(output[key], action)
 
 	return output
@@ -518,9 +540,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 /datum/preferences/proc/get_default_randomization()
 	var/list/default_randomization = list()
 
-	for (var/preference_key in GLOB.preference_entries_by_key)
+	for(var/preference_key in GLOB.preference_entries_by_key)
 		var/datum/preference/preference = GLOB.preference_entries_by_key[preference_key]
-		if (preference.is_randomizable() && preference.randomize_by_default)
+		if(preference.is_randomizable() && preference.randomize_by_default)
 			default_randomization[preference_key] = RANDOM_ENABLED
 
 	return default_randomization

--- a/code/modules/client/preferences/security_department.dm
+++ b/code/modules/client/preferences/security_department.dm
@@ -5,12 +5,6 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	savefile_key = "prefered_security_department"
 
-// This is what that #warn wants you to remove :)
-/datum/preference/choiced/security_department/deserialize(input, datum/preferences/preferences)
-	if (!(input in GLOB.security_depts_prefs))
-		return SEC_DEPT_NONE
-	return ..(input, preferences)
-
 /datum/preference/choiced/security_department/init_possible_values()
 	return GLOB.security_depts_prefs
 

--- a/code/modules/ghost_roles/customization.dm
+++ b/code/modules/ghost_roles/customization.dm
@@ -1,0 +1,36 @@
+/**
+ * Datums for ghost role customization, responsible for handling what character slots roles share, as well as applying relevant restrictions on them.
+ * Pretty bare-bones for now, but still probably better to keep those as datums.
+ */
+/datum/offstation_customization
+	/// What slot name will be used on the character setup?
+	var/slot_name = ""
+	/// The savefile key we'll be using. MUST use dashes for spaces (i.e "very-epic-ghostrole")
+	var/savefile_key = ""
+	/// What species can we use? Leave as null if you want to inherit GLOB.roundstart_races.
+	var/list/species_whitelist = null
+
+
+/datum/offstation_customization/ashwalker
+	slot_name = "Ashwalkers"
+	savefile_key = "ashwalker"
+	species_whitelist = list(/datum/species/lizard/ashwalker)
+
+/datum/offstation_customization/syndicate_outpost
+	slot_name = "Syndicate Outpost"
+	savefile_key = "syndicate-lavaland"
+	//species_whitelist = list(/datum/species/human) //someday my love
+
+/datum/offstation_customization/golem
+	slot_name = "Free Golems"
+	savefile_key = "golem"
+	species_whitelist = list(/datum/species/golem)
+
+/datum/offstation_customization/hermit
+	slot_name = "Stranded Hermit"
+	savefile_key = "hermit"
+
+/datum/offstation_customization/syndicate_battlecruiser
+	slot_name = "Syndicate Battlecruiser Crew"
+	savefile_key = "cybersun"
+	//species_whitelist = list(/datum/species/human)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -254,7 +254,7 @@
 	if(QDELETED(src) || !client)
 		return // Disconnected while checking for the appearance ban.
 	if(!isAI(spawning_mob)) // Unfortunately there's still snowflake AI code out there.
-		mind.original_character_slot_index = client.prefs.default_slot
+		mind.original_character_slot_index = client.prefs.current_char_id
 		mind.transfer_to(spawning_mob) //won't transfer key since the mind is not active
 		mind.set_original_character(spawning_mob)
 	client.init_verbs()

--- a/code/modules/mob/living/carbon/human/_species.dm
+++ b/code/modules/mob/living/carbon/human/_species.dm
@@ -1,10 +1,3 @@
-GLOBAL_LIST_EMPTY(roundstart_races)
-///List of all roundstart languages by path
-GLOBAL_LIST_EMPTY(roundstart_languages)
-
-/// An assoc list of species types to their features (from get_features())
-GLOBAL_LIST_EMPTY(features_by_species)
-
 /**
  * # species datum
  *

--- a/code/modules/mob/living/carbon/human/human_helpers.dm
+++ b/code/modules/mob/living/carbon/human/human_helpers.dm
@@ -183,7 +183,7 @@
 		return
 
 	var/path = "data/player_saves/[ckey[1]]/[ckey]/scars.sav"
-	var/loaded_char_slot = client.prefs.default_slot
+	var/loaded_char_slot = client.prefs.current_char_id
 
 	if(!loaded_char_slot || !fexists(path))
 		return FALSE

--- a/code/modules/mob_spawn/ghost_roles/spider_roles.dm
+++ b/code/modules/mob_spawn/ghost_roles/spider_roles.dm
@@ -167,12 +167,8 @@
  * Makes a ghost into a spider based on the type of egg cluster.
  *
  * Allows a ghost to get a prompt to use the egg cluster to become a spider.
- *
- * Arguments:
- * * user - The ghost attempting to become a spider
- * * newname - If set, renames the mob to this name
  */
-/obj/effect/mob_spawn/ghost_role/spider/create(mob/user, newname)
+/obj/effect/mob_spawn/ghost_role/spider/create(mob/user, load_custom_char)
 	var/list/spider_list = list()
 	var/list/display_spiders = list()
 	for(var/choice in potentialspawns)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3538,6 +3538,7 @@
 #include "code\modules\food_and_drinks\restaurant\customers\_customer.dm"
 #include "code\modules\forensics\_forensics.dm"
 #include "code\modules\forensics\forensics_helpers.dm"
+#include "code\modules\ghost_roles\customization.dm"
 #include "code\modules\hallucination\_hallucination.dm"
 #include "code\modules\hallucination\battle.dm"
 #include "code\modules\hallucination\body.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/CharacterPreferenceWindow.tsx
@@ -18,31 +18,6 @@ enum Page {
   Quirks,
 }
 
-const CharacterProfiles = (props: {
-  activeSlot: number;
-  onClick: (index: number) => void;
-  profiles: (string | null)[];
-}) => {
-  const { profiles } = props;
-
-  return (
-    <Stack justify="center" wrap>
-      {profiles.map((profile, slot) => (
-        <Stack.Item key={slot}>
-          <Button
-            selected={slot === props.activeSlot}
-            onClick={() => {
-              props.onClick(slot);
-            }}
-            fluid>
-            {profile ?? 'New Character'}
-          </Button>
-        </Stack.Item>
-      ))}
-    </Stack>
-  );
-};
-
 export const CharacterPreferenceWindow = (props, context) => {
   const { act, data } = useBackend<PreferencesMenuData>(context);
 
@@ -85,15 +60,37 @@ export const CharacterPreferenceWindow = (props, context) => {
       <Window.Content scrollable>
         <Stack vertical fill>
           <Stack.Item>
-            <CharacterProfiles
-              activeSlot={data.active_slot - 1}
-              onClick={(slot) => {
-                act('change_slot', {
-                  slot: slot + 1,
-                });
-              }}
-              profiles={data.character_profiles}
-            />
+            <Stack justify="center" wrap>
+              {data.character_profiles['main'].map((profile, slot_id) => (
+                <Stack.Item key={slot_id}>
+                  <Button
+                    selected={slot_id === data.active_slot_id - 1}
+                    onClick={() => {
+                      act('change_slot', {
+                        slot_key: 'main',
+                        slot_id: slot_id + 1,
+                      });
+                    }}
+                    fluid>
+                    {profile ?? 'FUNKY CODE, FUCK.'}
+                  </Button>
+                </Stack.Item>
+              ))}
+              {data.character_profiles['main'].length < data.max_slots_main && (
+                <Stack.Item>
+                  <Button
+                    onClick={() => {
+                      act('new_slot', {
+                        slot_key: 'main',
+                      });
+                    }}
+                    content="+"
+                    fluid
+                  />
+                </Stack.Item>
+              )}
+              <Stack.Item></Stack.Item>
+            </Stack>
           </Stack.Item>
 
           {!data.content_unlocked && (

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/QuirksPage.tsx
@@ -131,7 +131,7 @@ export const QuirksPage = (props, context) => {
 
   const [selectedQuirks, setSelectedQuirks] = useLocalState(
     context,
-    `selectedQuirks_${data.active_slot}`,
+    `selectedQuirks_${data.active_slot_key}_${data.active_slot_id}`,
     data.selected_quirks
   );
 

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/data.ts
@@ -123,7 +123,7 @@ export enum Window {
 
 export type PreferencesMenuData = {
   character_preview_view: string;
-  character_profiles: (string | null)[];
+  character_profiles: Record<string, string[] | null>[];
 
   character_preferences: {
     clothing: Record<string, string>;
@@ -168,7 +168,11 @@ export type PreferencesMenuData = {
   antag_days_left?: Record<string, number>;
   selected_antags: string[];
 
-  active_slot: number;
+  active_slot_id: number;
+  active_slot_key: number;
+  max_slots_main: number;
+  max_slots_ghost: number;
+
   name_to_use: string;
 
   window: Window;

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/base.tsx
@@ -319,7 +319,7 @@ export const FeatureValueInput = (
 
   const [predictedValue, setPredictedValue] = useLocalState(
     context,
-    `${props.featureId}_predictedValue_${data.active_slot}`,
+    `${props.featureId}_predictedValue_${data.active_slot_key}_${data.active_slot_id}`,
     props.value
   );
 


### PR DESCRIPTION
## About The Pull Request

Lets players create custom characters for ghost roles, as well as changing the character setup so it only shows slots that are in use.

- [X] Beautify char slots
- [X] Ghost role char backend
- [ ] Ghost role char frontend

## Why It's Good For The Game

Roleplay or something, plus epic flex on Skyrat and the likes.

## Pre-Merge Checklist
<!-- Don't bother filling these in while creating your Pull Request, just click the checkboxes after the Pull Request is opened and you are redirected to the page. -->
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.
<!-- Neither the compiler nor workflow checks are perfect at detecting runtimes and errors. It is important to test your code/feature/fix locally. -->

## Changelog

:cl:
add: ghost roles now support custom characters
qol: character setup now only shows character slots that are in use
code: touched up preferences code a tiny bit
/:cl:
