### PR TITLE
Title screen splash text

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -269,6 +269,7 @@
 
 #define LOBBY_BACKGROUND_LAYER 3
 #define LOBBY_BUTTON_LAYER 4
+#define LOBBY_SPLASH_LAYER 5
 
 ///cinematics are "below" the splash screen
 #define CINEMATIC_LAYER -1

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -34,6 +34,32 @@
 	icon_state = "background"
 	screen_loc = "TOP,CENTER:-61"
 
+/atom/movable/screen/lobby/splashtext
+	layer = LOBBY_SPLASH_LAYER
+	icon = null
+	icon_state = null
+	screen_loc = "TOP-4:16,CENTER-2:-16"
+	maptext_width = 256
+	maptext_height = 32
+	maptext_x = -96
+
+/atom/movable/screen/lobby/splashtext/Initialize(mapload)
+	. = ..()
+	if(config.splashtext)
+		update_splash(config.splashtext)
+	transform = transform.Turn(20)
+	animate_splash()
+
+/atom/movable/screen/lobby/splashtext/proc/update_splash(new_splash)
+	maptext = MAPTEXT_PIXELLARI(span_color("<span style='text-align: center;'>[new_splash]</span>", COLOR_YELLOW))
+
+/atom/movable/screen/lobby/splashtext/proc/animate_splash()
+	var/matrix/big_transform = matrix(transform)
+	big_transform.Scale(1.1, 1.1)
+	var/matrix/small_transform = matrix(transform)
+	animate(src, transform = small_transform, time = 2 SECONDS, loop = -1, flags = ANIMATION_PARALLEL)
+	animate(transform = big_transform, time = 2 SECONDS)
+
 /atom/movable/screen/lobby/button
 	///Is the button currently enabled?
 	var/enabled = TRUE

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -18,6 +18,7 @@
 	var/list/mode_reports
 	var/list/mode_false_report_weight
 
+	var/splashtext
 	var/motd
 	var/policy
 	var/datum/rules/rules
@@ -95,6 +96,7 @@
 		LoadEntries("ezdb.txt")
 	loadmaplist(CONFIG_MAPS_FILE)
 	LoadMOTD()
+	LoadSplashtext()
 	LoadPolicy()
 	LoadRules()
 	LoadChatFilter()
@@ -314,6 +316,13 @@
 	var/tm_info = GLOB.revdata.GetTestMergeInfo()
 	if(motd || tm_info)
 		motd = motd ? "[motd]<br>[tm_info]" : tm_info
+
+/// Picks a random splash text from the available pool of splash texts
+/datum/controller/configuration/proc/LoadSplashtext()
+	var/list/splashtexts = CONFIG_GET(str_list/splashtext)
+	if(!length(splashtexts))
+		return
+	splashtext = pick(splashtexts)
 
 /*
 Policy file should be a json file with a single object.

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -714,3 +714,6 @@
 /// automated age gate that only accepts users that confirm they are 18+
 /datum/config_entry/flag/age_gate
 	default = FALSE
+
+/// splash text that displays on the hub as well as on the lobby screen
+/datum/config_entry/str_list/splashtext

--- a/code/game/world.dm
+++ b/code/game/world.dm
@@ -363,7 +363,9 @@ GLOBAL_VAR(restart_counter)
 		features += "Respawn disabled"
 	else
 		features += "Respawn enabled"
-	if(!CONFIG_GET(flag/allow_ai))
+	if(CONFIG_GET(flag/allow_ai))
+		features += "AI enabled"
+	else
 		features += "AI disabled"
 	hostedby = CONFIG_GET(string/hostedby)
 
@@ -389,7 +391,10 @@ GLOBAL_VAR(restart_counter)
 	var/tagline = CONFIG_GET(string/servertagline)
 	if(tagline)
 		new_status += "<br>[tagline]"
+	if(config.splashtext)
+		new_status += "<br><i>[config.splashtext]</i>"
 
+	new_status += "<br>"
 	if(length(features))
 		new_status += "<br>\[[jointext(features, ", ")]\]"
 	var/roleplaylevel = CONFIG_GET(string/roleplaylevel)

--- a/config/config.txt
+++ b/config/config.txt
@@ -6,6 +6,7 @@ $include comms.txt
 $include logging.txt
 $include resources.txt
 $include interviews.txt
+$include splashtext.txt
 $include lua.txt
 $include auxtools.txt
 

--- a/config/splashtext.txt
+++ b/config/splashtext.txt
@@ -1,0 +1,37 @@
+# Splash text that appears on the title screen as well as the hub
+# The game will pick one of these to be displayed per round, if possible
+SPLASHTEXT 0% lag free!
+SPLASHTEXT 0% bug free!
+SPLASHTEXT More unstable than a Bethesda game!
+SPLASHTEXT Removed Buddy Loraine.
+SPLASHTEXT Nominated "Worst server ever" by famous youtuber Panigity!
+SPLASHTEXT The sign is a subtle joke. The shop is called "Sneed's Feed & Seed"...
+SPLASHTEXT Come over here and kiss me on my hot mouth... I'm feeling ROMANTICAL.
+SPLASHTEXT Rise and grind - Motivational video
+SPLASHTEXT This ain't your grandma's furry server!
+SPLASHTEXT SS13's "oldest" anarchy server!
+SPLASHTEXT The server below me sucks!
+SPLASHTEXT SS13 greytider eats you obby
+SPLASHTEXT lofi hip hop radio - beats to relax/study to
+SPLASHTEXT SS13 remade in Holy C!
+SPLASHTEXT All species except Felinid have been disabled.
+SPLASHTEXT Rebased to a Bay Luna fork!
+SPLASHTEXT Also try Escape From Nevado!
+SPLASHTEXT Built with stolen and unlicensed assets!
+SPLASHTEXT Built with Free and Open Source Software!
+SPLASHTEXT The allegations are false!
+SPLASHTEXT Now with multiplayer!
+SPLASHTEXT Made by the most dangerous man on SS13!
+SPLASHTEXT Being locally hosted on my mom's computer!
+SPLASHTEXT All is fair in love and war!
+SPLASHTEXT Includes raycasted 3D rendering technology!
+SPLASHTEXT Not Steam Deck certified!
+SPLASHTEXT Includes "Venom" antag!
+SPLASHTEXT Will you bite the hand that feeds?
+SPLASHTEXT The fire is gone!
+SPLASHTEXT Power for power!
+SPLASHTEXT This server is a safe space!
+SPLASHTEXT 0 players online!
+SPLASHTEXT Fuck you, Skyrat!
+SPLASHTEXT Fuck you, Bubbers!
+SPLASHTEXT Fuck you, TG!


### PR DESCRIPTION
## About The Pull Request

Adds minecraft splashtext on the title screen. It shows up on the hub entry too!
![image](https://github.com/NovusSS13/NovusSS13/assets/82850673/f5541d10-12bd-4073-b733-f11d602c78b3)

## Why It's Good For The Game

It's soul

## Pre-Merge Checklist
- [x] You tested this on a local server.
- [x] This code did not runtime during testing.
- [x] You documented all of your changes.

## Changelog

:cl:
add: Added minecraft splash text to the title screen. The splash text varies by round and shows up on the hub entry too.
/:cl:
