### PR TITLE
Implements runechat color preference, fixes age gate bugs, small shit

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1224,7 +1224,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
  * * ignore_global_list - If true, will not use the global list of runechat colors to generate colors
  */
 /proc/colorize_string(string, seed, sat_shift = 1, lum_shift = 1, sat_max = 0.75, sat_min = 0.6, lum_max = 0.75, lum_min = 0.65, ignore_global_list = FALSE)
-	// currently, we ignore sat_min and lum_min for global colors
+	// currently, we ignore sat_max, sat_min, and lum_max, lum_min for global colors
 	if(!ignore_global_list && GLOB.chat_colors[string])
 		var/list/hsv_color = rgb2num(GLOB.chat_colors[string], COLORSPACE_HSV)
 		var/h = hsv_color[1]

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1226,6 +1226,9 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 /proc/colorize_string(string, seed, sat_shift = 1, lum_shift = 1, sat_max = 0.75, sat_min = 0.6, lum_max = 0.75, lum_min = 0.65, ignore_global_list = FALSE)
 	// currently, we ignore sat_max, sat_min, and lum_max, lum_min for global colors
 	if(!ignore_global_list && GLOB.chat_colors[string])
+		// not necessary to do anything else in this case
+		if(sat_shift == 1 && lum_shift == 1)
+			return GLOB.chat_colors[string]
 		var/list/hsv_color = rgb2num(GLOB.chat_colors[string], COLORSPACE_HSV)
 		var/h = hsv_color[1]
 		var/s = clamp(hsv_color[2] * clamp(sat_shift, 0, 1), 0, 255)

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1228,8 +1228,8 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 	if(!ignore_global_list && GLOB.chat_colors[string])
 		var/list/hsv_color = rgb2num(GLOB.chat_colors[string], COLORSPACE_HSV)
 		var/h = hsv_color[1]
-		var/s = clamp(round(hsv_color[2] * clamp(sat_shift, 0, 1), 1), 0, 255)
-		var/l = clamp(round(hsv_color[3] * clamp(lum_shift, 0, 1), 1), 0, 255)
+		var/s = clamp(hsv_color[2] * clamp(sat_shift, 0, 1), 0, 255)
+		var/l = clamp(hsv_color[3] * clamp(lum_shift, 0, 1), 0, 255)
 		return rgb(h, s, l, space = COLORSPACE_HSL)
 
 	// seed to help randomness

--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1213,7 +1213,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
  * These seem to be favorable for displaying on the map.
  *
  * Arguments:
- * * name - The name to generate a color for
+ * * string - The string to generate a color for
  * * seed - An override seed, in case you don't want to use the default static one
  * * sat_shift - A value between 0 and 1 that will be multiplied against the saturation
  * * lum_shift - A value between 0 and 1 that will be multiplied against the luminescence
@@ -1221,8 +1221,17 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
  * * sat_min - A value between 0 and 1, minimum saturation of the color in the HSL space
  * * lum_max - A value between 0 and 1, maximum luminescence of the color in the HSL space
  * * lum_min - A value between 0 and 1, minimum luminescence of the color in the HSL space
+ * * ignore_global_list - If true, will not use the global list of runechat colors to generate colors
  */
-/proc/colorize_string(name, seed, sat_shift = 1, lum_shift = 1, sat_max = 0.75, sat_min = 0.6, lum_max = 0.75, lum_min = 0.65)
+/proc/colorize_string(string, seed, sat_shift = 1, lum_shift = 1, sat_max = 0.75, sat_min = 0.6, lum_max = 0.75, lum_min = 0.65, ignore_global_list = FALSE)
+	// currently, we ignore sat_min and lum_min for global colors
+	if(!ignore_global_list && GLOB.chat_colors[string])
+		var/list/hsv_color = rgb2num(GLOB.chat_colors[string], COLORSPACE_HSV)
+		var/h = hsv_color[1]
+		var/s = clamp(round(hsv_color[2] * clamp(sat_shift, 0, 1), 1), 0, 255)
+		var/l = clamp(round(hsv_color[3] * clamp(lum_shift, 0, 1), 1), 0, 255)
+		return rgb(h, s, l, space = COLORSPACE_HSL)
+
 	// seed to help randomness
 	var/static/rseed = rand(1,26)
 
@@ -1230,7 +1239,7 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 		seed = rseed
 
 	// get hsl using the selected 6 characters of the md5 hash
-	var/hash = copytext(md5(name + GLOB.round_id), seed, seed + 6)
+	var/hash = copytext(md5(string + GLOB.round_id), seed, seed + 6)
 	var/h = hex2num(copytext(hash, 1, 3)) * (360 / 255)
 	var/s = (hex2num(copytext(hash, 3, 5)) >> 2) * ((sat_max - sat_min) / 63) + sat_min
 	var/l = (hex2num(copytext(hash, 5, 7)) >> 2) * ((lum_max - lum_min) / 63) + lum_min

--- a/code/_globalvars/lists/flavor_misc.dm
+++ b/code/_globalvars/lists/flavor_misc.dm
@@ -167,6 +167,7 @@ GLOBAL_LIST_INIT(body_types, list(
 ))
 
 	//Colors
+//normal ethereal colors
 GLOBAL_LIST_INIT(color_list_ethereal, list(
 	"Blue" = "#3399ff",
 	"Bright Yellow" = "#ffff99",
@@ -189,6 +190,7 @@ GLOBAL_LIST_INIT(color_list_ethereal, list(
 	"White" = "#f2f2f2",
 ))
 
+//lustrous ethereal color list
 GLOBAL_LIST_INIT(color_list_lustrous, list(
 	"Cyan Blue" = "#00ffff",
 	"Sky Blue" = "#37c0ff",
@@ -197,6 +199,16 @@ GLOBAL_LIST_INIT(color_list_lustrous, list(
 	"Bright Red" = "#fa2d2d",
 ))
 
+//runechat colors
+GLOBAL_LIST_INIT(chat_colors, list(
+	"Unknown" = COLOR_GRAY,
+))
+
+GLOBAL_LIST_INIT(protected_chat_colors, list(
+	"Unknown" = COLOR_GRAY,
+))
+
+//stores the ghost forms that support directional sprites
 GLOBAL_LIST_INIT(ghost_forms_with_directions_list, list(
 	"catghost",
 	"ghost_black",
@@ -227,8 +239,8 @@ GLOBAL_LIST_INIT(ghost_forms_with_directions_list, list(
 	"ghostking",
 	"skeleghost",
 ))
-//stores the ghost forms that support directional sprites
 
+//stores the ghost forms that support hair and other such things
 GLOBAL_LIST_INIT(ghost_forms_with_accessories_list, list(
 	"ghost_black",
 	"ghost_blazeit",
@@ -255,7 +267,6 @@ GLOBAL_LIST_INIT(ghost_forms_with_accessories_list, list(
 	"ghost",
 	"skeleghost",
 ))
-//stores the ghost forms that support hair and other such things
 
 GLOBAL_LIST_INIT(security_depts_prefs, sort_list(list(
 	SEC_DEPT_ENGINEERING,

--- a/code/_onclick/hud/new_player.dm
+++ b/code/_onclick/hud/new_player.dm
@@ -6,9 +6,6 @@
 	if(!owner || !owner.client)
 		return
 
-	if (owner.client.interviewee || owner.client.age_gated)
-		return
-
 	var/list/buttons = subtypesof(/atom/movable/screen/lobby)
 	for(var/button_type in buttons)
 		var/atom/movable/screen/lobby/lobbyscreen = new button_type()
@@ -39,7 +36,7 @@
 	icon = null
 	icon_state = null
 	screen_loc = "TOP-4:16,CENTER-2:-16"
-	maptext_width = 256
+	maptext_width = 288
 	maptext_height = 32
 	maptext_x = -96
 

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -2179,8 +2179,8 @@
 	LAZYADD(update_overlays_on_z, glow_appearance)
 
 /// Small proc that sets the chat color of an atom based on name
-/atom/proc/update_chat_color()
-	if(chat_color_name == name || !ismob(src))
+/atom/proc/update_chat_color(forced = FALSE)
+	if(!forced && ((chat_color_name == name) || !ismob(src)))
 		return FALSE
 	chat_color = colorize_string(name)
 	chat_color_darkened = colorize_string(name, sat_shift = 0.85, lum_shift = 0.85)

--- a/code/modules/client/age_gate/age_gate.dm
+++ b/code/modules/client/age_gate/age_gate.dm
@@ -62,14 +62,15 @@
 	owner.update_flag_db(DB_FLAG_AGE_VETTED, TRUE)
 	to_chat(owner, span_adminsay("You have successfully passed the age gate. You will automatically be reconnected to the server in 5 seconds."))
 	addtimer(CALLBACK(src, PROC_REF(reconnect_owner), owner), 5 SECONDS)
-	qdel(src)
 	return TRUE
 
 /datum/age_gate/proc/reconnect_owner(client/goner)
 	SIGNAL_HANDLER
-	if(QDELETED(goner))
-		return
-	winset(goner, null, "command=.reconnect")
+
+	if(!QDELETED(goner))
+		winset(goner, null, "command=.reconnect")
+	if(!QDELETED(src))
+		qdel(src)
 
 /datum/age_gate/proc/validate_submission(month, year)
 	var/age_gate_result = FALSE

--- a/code/modules/client/preferences/_preference.dm
+++ b/code/modules/client/preferences/_preference.dm
@@ -74,9 +74,9 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 	/// DOES have random body on, will this already be randomized?
 	var/randomize_by_default = TRUE
 
-	/// If the selected species has this in its /datum/species/mutant_bodyparts,
+	/// If the selected species has this in its /datum/species/get_features() return list,
 	/// will show the feature as selectable.
-	var/relevant_mutant_bodypart = null
+	var/relevant_feature = null
 
 	/// If the selected species has this in its /datum/species/inherent_traits,
 	/// will show the feature as selectable.
@@ -255,7 +255,7 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 	SHOULD_NOT_SLEEP(TRUE)
 
 	if ( \
-		!isnull(relevant_mutant_bodypart) \
+		!isnull(relevant_feature) \
 		|| !isnull(relevant_inherent_trait) \
 		|| !isnull(relevant_cosmetic_organ) \
 		|| !isnull(relevant_head_flag) \
@@ -382,7 +382,10 @@ GLOBAL_LIST_INIT(preference_entries_by_key, init_preference_entries_by_key())
 /datum/preference/color/deserialize(input, datum/preferences/preferences)
 	return sanitize_hexcolor(input)
 
-/datum/preference/color/create_default_value()
+/datum/preference/color/create_default_value(datum/preferences/preferences)
+	if(preferences)
+		var/list/mcolor = preferences.read_preference(/datum/preference/tricolor/mutant/mutant_color)
+		return mcolor[1]
 	return "#FFFFFF"
 
 /datum/preference/color/create_random_value()

--- a/code/modules/client/preferences/runechat.dm
+++ b/code/modules/client/preferences/runechat.dm
@@ -23,3 +23,41 @@
 
 /datum/preference/numeric/max_chat_length/create_default_value(datum/preferences/preferences)
 	return CHAT_MESSAGE_MAX_LENGTH
+
+/datum/preference/toggle/random_chat_color
+	priority = PREFERENCE_PRIORITY_NAME_MODIFICATIONS //does not actually matter but w/e
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_key = "random_chat_color"
+	savefile_identifier = PREFERENCE_CHARACTER
+	default_value = TRUE
+
+//by it's very nature, when this is true that means it's random...
+/datum/preference/toggle/random_chat_color/create_random_value(datum/preferences/preferences)
+	return TRUE
+
+//not needed of course
+/datum/preference/toggle/random_chat_color/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/prefs)
+	return
+
+/datum/preference/color/chat_color
+	priority = PREFERENCE_PRIORITY_NAME_MODIFICATIONS
+	category = PREFERENCE_CATEGORY_NON_CONTEXTUAL
+	savefile_key = "chat_color"
+	savefile_identifier = PREFERENCE_CHARACTER
+
+/datum/preference/color/chat_color/is_accessible(datum/preferences/preferences)
+	return ..() && preferences && !preferences.read_preference(/datum/preference/toggle/random_chat_color)
+
+/datum/preference/color/chat_color/create_default_value(datum/preferences/preferences)
+	. = ..()
+	var/say_my_name = preferences?.read_preference(/datum/preference/name/real_name)
+	if(say_my_name)
+		return colorize_string(say_my_name)
+	return "#[random_color()]"
+
+/datum/preference/color/chat_color/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/prefs)
+	if(!is_accessible(prefs) || isdummy(target))
+		return
+	if(isnull(GLOB.protected_chat_colors[target.real_name]))
+		GLOB.chat_colors[target.real_name] = value
+	target.update_chat_color(forced = TRUE)

--- a/code/modules/client/preferences/species_features/ethereal.dm
+++ b/code/modules/client/preferences/species_features/ethereal.dm
@@ -3,8 +3,9 @@
 	savefile_identifier = PREFERENCE_CHARACTER
 	category = PREFERENCE_CATEGORY_FEATURES
 	main_feature_name = "Ethereal color"
-	should_generate_icons = TRUE
+	relevant_feature = "ethcolor"
 	modified_feature = "ethcolor"
+	should_generate_icons = TRUE
 
 /datum/preference/choiced/mutant/ethereal_color/init_possible_values()
 	return assoc_to_keys(GLOB.color_list_ethereal)

--- a/code/modules/interview/interview.dm
+++ b/code/modules/interview/interview.dm
@@ -58,7 +58,7 @@
 		SEND_SOUND(owner, sound('sound/effects/adminhelp.ogg'))
 		to_chat(owner, "<font color='red' size='4'><b>-- Interview Update --</b></font>" \
 			+ "\n[span_adminsay("Your interview was approved, you will now be reconnected in 5 seconds.")]", confidential = TRUE)
-		addtimer(CALLBACK(src, PROC_REF(reconnect_owner)), 50)
+		addtimer(CALLBACK(src, PROC_REF(reconnect_owner)), 5 SECONDS)
 
 /**
  * Denies the interview and adds the owner to the cooldown for new interviews.
@@ -84,7 +84,7 @@
  * Forces client to reconnect, used in the callback from approval
  */
 /datum/interview/proc/reconnect_owner()
-	if (!owner)
+	if (QDELETED(owner))
 		return
 	winset(owner, null, "command=.reconnect")
 

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -371,8 +371,7 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 	var/talk_icon_state = say_test(message_raw)
 	for(var/mob/M in listening)
 		if(M.client)
-			if(!M.client.prefs.read_preference(/datum/preference/toggle/enable_runechat) || (SSlag_switch.measures[DISABLE_RUNECHAT] && !HAS_TRAIT(src, TRAIT_BYPASS_MEASURES)))
-				speech_bubble_recipients.Add(M.client)
+			speech_bubble_recipients.Add(M.client)
 			found_client = TRUE
 
 	if(voice && found_client && !message_mods[MODE_CUSTOM_SAY_ERASE_INPUT] && !HAS_TRAIT(src, TRAIT_SIGN_LANG))

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/runechat_color.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/character_preferences/runechat_color.tsx
@@ -1,0 +1,11 @@
+import { Feature, FeatureColorInput, FeatureToggle, CheckboxInput } from '../base';
+
+export const random_chat_color: FeatureToggle = {
+  name: 'Random chat color',
+  component: CheckboxInput,
+};
+
+export const chat_color: Feature<string> = {
+  name: 'Chat color',
+  component: FeatureColorInput,
+};


### PR DESCRIPTION
## About The Pull Request

Simple runechat color preferences

## Why It's Good For The Game

Character customization cool

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
add: You can now customize your runechat color. Yippie.
fix: Age gate is less of a buggy mess now and will try to properly reconnect you to the game.
/:cl: