### PR TITLE
This started as a PR about inverting chat colors on light mode, but it's not possible on Internet Explorer 9

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -235,7 +235,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	return "0"
 
 /atom/movable/proc/GetVoice()
-	return "[src]" //Returns the atom's name, prepended with 'The' if it's not a proper noun
+	return "[src.name]"
 
 //HACKY VIRTUALSPEAKER STUFF BEYOND THIS POINT
 //these exist mostly to deal with the AIs hrefs and job stuff.


### PR DESCRIPTION
sadge