### PR TITLE
Radio messages no longer display the user's chat color

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -117,9 +117,6 @@ GLOBAL_LIST_INIT(freqtospan, list(
 	var/list/stored_name = list(null)
 	SEND_SIGNAL(speaker, COMSIG_MOVABLE_MESSAGE_GET_NAME_PART, stored_name, visible_name)
 	namepart = stored_name[NAME_PART_INDEX] || "[speaker.GetVoice()]"
-	if(namepart && speaker.chat_color)
-		var/actual_color = colorize_string(namepart) //signal means we have to do this dumb shit...
-		namepart = span_color(namepart, actual_color)
 
 	//End name span.
 	var/endspanpart = "</span>"


### PR DESCRIPTION
## About The Pull Request

This shit looks AWFUL.
![image](https://github.com/NovusSS13/NovusSS13/assets/82850673/d52ca5c6-be1f-4aeb-9083-1e171462f867)

## Why It's Good For The Game

Prettier!

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
qol: Radio messages no longer use the user's chat color.
/:cl: