### PR TITLE
The final solution - Removes digitigrade preference

### DIFF
--- a/code/modules/client/preferences/species_features/mutant.dm
+++ b/code/modules/client/preferences/species_features/mutant.dm
@@ -61,32 +61,6 @@
 								update = FALSE)
 	target.update_body(is_creating = TRUE) //grumble grumble
 
-/datum/preference/choiced/mutant/leg_type
-	savefile_key = "feature_leg_type"
-	savefile_identifier = PREFERENCE_CHARACTER
-	category = PREFERENCE_CATEGORY_SECONDARY_FEATURES
-	modified_feature = "legs"
-
-/datum/preference/choiced/mutant/leg_type/is_accessible(datum/preferences/preferences)
-	. = ..()
-	if(!.)
-		return FALSE
-
-	var/datum/species/species_type = preferences.read_preference(/datum/preference/choiced/species)
-	return (initial(species_type.digitigrade_customization) == DIGITIGRADE_OPTIONAL)
-
-/datum/preference/choiced/mutant/leg_type/init_possible_values()
-	return assoc_to_keys_features(GLOB.legs_list)
-
-/datum/preference/choiced/mutant/leg_type/apply_to_human(mob/living/carbon/human/target, value, datum/preferences/prefs)
-	. = ..()
-	for(var/obj/item/bodypart/leg/leg in target.bodyparts)
-		if(value == LEGS_DIGITIGRADE)
-			leg.bodytype |= BODYTYPE_DIGITIGRADE
-		else
-			leg.bodytype &= ~BODYTYPE_DIGITIGRADE
-	target.update_body(is_creating = TRUE) //grumble grumble
-
 /datum/preference/choiced/mutant/frills
 	savefile_key = "feature_mutant_frills"
 	savefile_identifier = PREFERENCE_CHARACTER


### PR DESCRIPTION
## About The Pull Request

![chuditsover](https://github.com/NovusSS13/NovusSS13/assets/82850673/c145b432-bb74-4e9b-a3bf-599b6589b068)

## Why It's Good For The Game

I tried my best, but ultimately, byond limitations mean that an intelligent solution for digitigrade is currently not possible, and might not be possible in the foreseeable future.  It's fucking over.
![image](https://github.com/NovusSS13/NovusSS13/assets/82850673/d49dbf30-ef48-4967-b057-f4327d01e890)
![image](https://github.com/NovusSS13/NovusSS13/assets/82850673/48a84432-3233-416b-b2be-ec9472e95b83)
(Notice how the filter does not follow the transform, so lying down breaks everything!)

Digitigrade will be entirely relegated to ashwalkers.

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
del: You can no longer choose to be digitigrade on the character setup. Goodbye, sweet prince.
/:cl: