### PR TITLE
COMMAND RADIO IS FUCKING NAVY BLUE

### DIFF
--- a/interface/stylesheet.dm
+++ b/interface/stylesheet.dm
@@ -42,7 +42,7 @@ em						{font-style: normal;	font-weight: bold;}
 .binarysay a:active, .binarysay a:visited {color: #88ff88;}
 .radio					{color: #008000;}
 .sciradio				{color: #993399;}
-.comradio				{color: #948f02;}
+.comradio				{color: #204090;}
 .secradio				{color: #a30000;}
 .medradio				{color: #337296;}
 .engradio				{color: #fb5613;}

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-dark.scss
@@ -336,7 +336,7 @@ em {
 }
 
 .comradio {
-  color: #fcdf03;
+  color: #5f5cff;
 }
 
 .secradio {

--- a/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
+++ b/tgui/packages/tgui-panel/styles/tgchat/chat-light.scss
@@ -353,7 +353,7 @@ em {
 }
 
 .comradio {
-  color: #948f02;
+  color: #204090;
 }
 
 .secradio {

--- a/tgui/packages/tgui-say/styles/colors.scss
+++ b/tgui/packages/tgui-say/styles/colors.scss
@@ -10,7 +10,7 @@ $_channel_map: (
   'Admin': #ffbbff,
   'AI': #d65d95,
   'CCom': #2681a5,
-  'Cmd': #fcdf03,
+  'Cmd': #5f5cff,
   'Engi': #f37746,
   'Hive': #855d85,
   'io': #1e90ff,

--- a/tgui/packages/tgui/constants.ts
+++ b/tgui/packages/tgui/constants.ts
@@ -22,7 +22,7 @@ export const UI_CLOSE = -1;
 export const COLORS = {
   // Department colors
   department: {
-    captain: '#c06616',
+    captain: '#5f5cff',
     security: '#e74c3c',
     medbay: '#3498db',
     science: '#9b59b6',
@@ -117,7 +117,7 @@ export const RADIO_CHANNELS = [
   {
     name: 'Command',
     freq: 1353,
-    color: '#fcdf03',
+    color: '#5f5cff',
   },
   {
     name: 'Medical',


### PR DESCRIPTION
## About The Pull Request

PORTS https://github.com/tgstation/tgstation/pull/68549

YOU KNOW WHY? BECAUSE EVERYTHING COMMAND RELATED IS BLUE. THE FUCKING DOORS, THE FUCKING LOCKERS, THE FUCKING CLOTHES. IT'S ALL FUCKING BLUE! IT'S NAVY BLUE!

## Why It's Good For The Game

IT'S ALL FUCKING BLUE. WHY IS THE RADIO NOT FUCKING BLUE?

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
qol: COMMAND RADIO IS NAVY BLUE AS GOD INTENDED. FUCK YOU.
/:cl: