### PR TITLE
Fixed handshaking and handholding not requiring the target to have hands.

### DIFF
--- a/code/datums/interactions/friendly.dm
+++ b/code/datums/interactions/friendly.dm
@@ -16,6 +16,16 @@
 	sound_vary = TRUE
 	sound_extrarange = -1
 
+/datum/interaction/friendly/handshake/evaluate_target(datum/component/interactable/user, datum/component/interactable/target, silent)
+	. = ..()
+	if(!.)
+		return
+	var/mob/living/carbon/human/human_target = target.parent
+	if(istype(human_target) && !human_target.get_bodypart(BODY_ZONE_L_ARM) && !human_target.get_bodypart(BODY_ZONE_R_ARM))
+		if(!silent)
+			to_chat(user, span_warning("[human_target.p_they(TRUE)] have no hands!"))
+		return FALSE
+
 /datum/interaction/friendly/hug
 	name = "Hug"
 	desc = "Give them a hug! How nice."

--- a/code/datums/interactions/romance.dm
+++ b/code/datums/interactions/romance.dm
@@ -11,6 +11,16 @@
 	user_message = span_love("You hold %TARGET's hand.")
 	target_message = span_love("%USER hold%USER_S your hand.")
 
+/datum/interaction/romance/handholding/evaluate_target(datum/component/interactable/user, datum/component/interactable/target, silent)
+	. = ..()
+	if(!.)
+		return
+	var/mob/living/carbon/human/human_target = target.parent
+	if(istype(human_target) && !human_target.get_bodypart(BODY_ZONE_L_ARM) && !human_target.get_bodypart(BODY_ZONE_R_ARM))
+		if(!silent)
+			to_chat(user, span_warning("[human_target.p_they(TRUE)] have no hands!"))
+		return FALSE
+
 /datum/interaction/romance/kisscheeks
 	name = "Kiss Cheeks"
 	desc = "Kiss them. On the cheek."


### PR DESCRIPTION
## About The Pull Request

You can't handshake or handhold someone with no arms! The option disappears completely if the target has no arms.

I was also going to add an evaluate_user to check if the user had arms but it's redundant since the user cannot use the interaction menu without arms anyways.

## Why It's Good For The Game

Le consistency

## Pre-Merge Checklist
- [✔️] You tested this on a local server.
- [✔️] This code did not runtime during testing.
- [✔️] You documented all of your changes.

## Changelog

:cl:
fix: Employees can no longer hold hands or come to friendly agreements with crewmembers without arms.
/:cl:
