### PR TITLE
Balloon alert preferences

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -1206,6 +1206,13 @@ GLOBAL_LIST_INIT(binary, list("0","1"))
 		text2num(semver_regex.group[3]),
 	)
 
+/// Punctuates a string, if it isn't already punctuated
+/proc/punctuate(string, punctuation = ".")
+	var/static/regex/punctuation_regex = regex(@"[^\w\s]$", "gi")
+	if(!punctuation_regex.Find(string))
+		return string + punctuation
+	return string
+
 /**
  * Gets a color for a name, will return the same color for a given string consistently within a round.
  *

--- a/code/modules/client/preferences/balloon_alert.dm
+++ b/code/modules/client/preferences/balloon_alert.dm
@@ -1,0 +1,9 @@
+/datum/preference/toggle/balloon_alerts_on_map
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "balloon_alerts_on_map"
+	savefile_identifier = PREFERENCE_PLAYER
+
+/datum/preference/toggle/balloon_alerts_on_chat
+	category = PREFERENCE_CATEGORY_GAME_PREFERENCES
+	savefile_key = "balloon_alerts_on_chat"
+	savefile_identifier = PREFERENCE_PLAYER

--- a/code/modules/mob/living/living_say.dm
+++ b/code/modules/mob/living/living_say.dm
@@ -463,10 +463,9 @@ GLOBAL_LIST_INIT(message_modes_stat_limits, list(
 		message = capitalize(message)
 		tts_message = capitalize(tts_message)
 
-	var/static/regex/punctuation_regex = regex(@"[^\w\s]$", "gi")
-	if(add_period && !punctuation_regex.Find(message))
-		message += "."
-		tts_message += "."
+	if(add_period)
+		message = punctuate(message)
+		tts_message = punctuate(tts_message)
 
 	///caps the length of individual letters to 3: ex: heeeeeeyy -> heeeyy
 	/// prevents TTS from choking on unrealistic text while keeping emphasis

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3172,6 +3172,7 @@
 #include "code\modules\client\preferences\ambient_occlusion.dm"
 #include "code\modules\client\preferences\assets.dm"
 #include "code\modules\client\preferences\auto_fit_viewport.dm"
+#include "code\modules\client\preferences\balloon_alert.dm"
 #include "code\modules\client\preferences\blood_type.dm"
 #include "code\modules\client\preferences\body_size.dm"
 #include "code\modules\client\preferences\body_type.dm"

--- a/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/balloon_alerts.tsx
+++ b/tgui/packages/tgui/interfaces/PreferencesMenu/preferences/features/game_preferences/balloon_alerts.tsx
@@ -1,0 +1,15 @@
+import { CheckboxInput, FeatureToggle } from '../base';
+
+export const balloon_alerts_on_map: FeatureToggle = {
+  name: 'Enable Balloon Alerts',
+  category: 'BALLOON',
+  description: 'Balloon alerts will show above objects and mobs.',
+  component: CheckboxInput,
+};
+
+export const balloon_alerts_on_chat: FeatureToggle = {
+  name: 'Enable Balloon Alert Messages',
+  category: 'BALLOON',
+  description: 'Balloon alerts will show on the chat box.',
+  component: CheckboxInput,
+};


### PR DESCRIPTION
## About The Pull Request

Adds two prefs, one for balloon alerts on the map and another for balloon alerts on the chat.


## Why It's Good For The Game

Quality of life

## Pre-Merge Checklist
- [ ] You tested this on a local server.
- [ ] This code did not runtime during testing.
- [ ] You documented all of your changes.

## Changelog

:cl:
qol: Balloon alerts last longer
qol: Added two preferences for balloon alerts - Balloon alerts on map, and balloon alerts on chat
/:cl: